### PR TITLE
feat: 장바구니 만료 기능 추가

### DIFF
--- a/src/main/java/com/example/outsourcing/cart/controller/CartController.java
+++ b/src/main/java/com/example/outsourcing/cart/controller/CartController.java
@@ -6,6 +6,7 @@ import com.example.outsourcing.cart.dto.CartResponseDto;
 import com.example.outsourcing.cart.dto.UpdateCartItemRequestDto;
 import com.example.outsourcing.cart.entity.Cart;
 import com.example.outsourcing.cart.service.CartService;
+import com.example.outsourcing.common.annotation.AuthUser;
 import com.example.outsourcing.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,50 +20,41 @@ public class CartController {
     private final CartService cartService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Void>> addItemtoCart(@RequestBody CartRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<Void>> addItemtoCart(
+            @AuthUser Long userId,
+            @RequestBody CartRequestDto requestDto) {
         String message = "\"장바구니에 메뉴가 추가되었습니다.\"";
-        Long userId = 1L;
-        // TODO 사용자 id도 카트에 넣어줘야함,
         cartService.addItemtoCart(userId, requestDto);
         return ResponseEntity.ok(ApiResponse.success(message));
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<CartResponseDto>> getCartItems() {
-        // TODO JWT 토큰을 통해서 유저아이디 가져오고, 장바구니 있는지 조회 필요
-        // TODO JWT토큰 가져오면 이거 삭제해야함, 더미 유저있다고 가정
-        Long userId = 1L;
-        // TODO 컨트롤러에서 장바구니 엔티티를 가져다가 리턴해준다? NONO 아닌거 같음
+    public ResponseEntity<ApiResponse<CartResponseDto>> getCartItems(@AuthUser Long userId) {
         String message = "\"장바구니를 조회했습니다.\"";
-
-        // 유저 아이디에 해당하는 장바구니 id없다면 서비스단에서 에러
         CartResponseDto responseDto = cartService.getCartDetails(userId);
-
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, message, responseDto));
     }
 
     @PatchMapping
-    public ResponseEntity<ApiResponse<Void>> updateCart(@RequestBody UpdateCartItemRequestDto requestDto) {
-        // TODO JWT 토큰을 통해서 유저아이디 가져오고, 장바구니 있는지 조회 필요
-        // TODO JWT토큰 가져오면 이거 삭제해야함, 더미 유저있다고 가정
-        Long userId = 1L;
+    public ResponseEntity<ApiResponse<Void>> updateCart(
+            @AuthUser Long userId,
+            @RequestBody UpdateCartItemRequestDto requestDto) {
         String message = "\"수정한 메뉴가 장바구니에 반영되었습니다.\"";
-
         cartService.updateCart(userId, requestDto);
         return ResponseEntity.ok(ApiResponse.success(message));
     }
 
     @DeleteMapping("/{cartId}")
-    public ResponseEntity<ApiResponse<Void>> deleteCartItem(@PathVariable Long cartId) {
-        cartService.deleteCartItem(cartId);
+    public ResponseEntity<ApiResponse<Void>> deleteCartItem(
+            @AuthUser Long userId,
+            @PathVariable Long cartId) {
+        cartService.deleteCartItem(userId,cartId);
         String message = "\"해당 메뉴가 장바구니에서 삭제되었습니다.\"";
         return ResponseEntity.ok(ApiResponse.success(message));
     }
 
     @DeleteMapping("/all")
-    public ResponseEntity<ApiResponse<Void>> clearCart() {
-        // TODO id는 헤더에서 가져오기
-        Long userId = 1L;
+    public ResponseEntity<ApiResponse<Void>> clearCart(@AuthUser Long userId) {
         cartService.clearCart(userId);
         String message = "\"장바구니가 삭제되었습니다.\"";
         return ResponseEntity.ok(ApiResponse.success(message));

--- a/src/main/java/com/example/outsourcing/cart/exception/CartEmptyException.java
+++ b/src/main/java/com/example/outsourcing/cart/exception/CartEmptyException.java
@@ -1,0 +1,7 @@
+package com.example.outsourcing.cart.exception;
+
+public class CartEmptyException extends RuntimeException {
+    public CartEmptyException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/outsourcing/cart/exception/CartExpiredException.java
+++ b/src/main/java/com/example/outsourcing/cart/exception/CartExpiredException.java
@@ -1,0 +1,7 @@
+package com.example.outsourcing.cart.exception;
+
+public class CartExpiredException extends RuntimeException {
+    public CartExpiredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/outsourcing/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/outsourcing/cart/repository/CartRepository.java
@@ -18,6 +18,6 @@ public interface CartRepository extends JpaRepository<Cart,Long> {
     void deleteByUserId(Long userId);
 
     // 사용자 id를 기준으로 마지막 장바구니의 수정시간 가져오기
-    @Query("SELECT MAX(c.updatedAt) FROM Cart c WHERE c.userId = :userId")
+    @Query("SELECT MAX(c.updatedAt) FROM Cart c WHERE c.user.id = :userId")
     Optional<LocalDateTime> findMaxUpdatedAtByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/outsourcing/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/outsourcing/cart/repository/CartRepository.java
@@ -1,8 +1,11 @@
 package com.example.outsourcing.cart.repository;
 
 import com.example.outsourcing.cart.entity.Cart;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,4 +17,7 @@ public interface CartRepository extends JpaRepository<Cart,Long> {
 
     void deleteByUserId(Long userId);
 
+    // 사용자 id를 기준으로 마지막 장바구니의 수정시간 가져오기
+    @Query("SELECT MAX(c.updatedAt) FROM Cart c WHERE c.userId = :userId")
+    Optional<LocalDateTime> findMaxUpdatedAtByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/outsourcing/cart/service/CartService.java
+++ b/src/main/java/com/example/outsourcing/cart/service/CartService.java
@@ -45,11 +45,13 @@ public class CartService {
         // 유저아이디로 저장된 장바구니가 있는경우 → 기존 장바구니 가게와 requestDto가게 정보 비교 필요
         if (cartOptional.isPresent()) {
             Cart cart = cartOptional.get();
+            // TODO 가게 다르면 사용자에게 메세지 보내야함
             if (cart.getStoreId() != requestDto.getStoreId()) {
-                // TODO 가게 다르면 사용자에게 메세지 보내야함
                 // 기존 장바구니에 있는 가게 메뉴를 담을 건지
                 // 아니면 새롭게 들어온 가게 메뉴로 장바구니 담을건지
                 // 어떻게 처리하지?
+                // 04_27 일단 바로 지워버리기
+                clearCart(userId);
             }
         }
         // 기존 장바구니 있지만, 가게가 같은경우
@@ -153,7 +155,14 @@ public class CartService {
 
     }
 
-    public void deleteCartItem(Long cartId) {
+    public void deleteCartItem(Long userId, Long cartId) {
+        Cart cart = cartRepository.findById(cartId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 아이디의 장바구니가 없습니다!"));
+        // 장바구니 주인의 아이디와 현재 로그인 아이디 비교
+        if (cart.getUser().getId().equals(userId)) {
+            // 에러메세지 내용 통일 (또는 권한이 없습니다?)
+            throw new RuntimeException("다른 사용자의 장바구니에 접근할 수 없습니다!");
+        }
         cartRepository.deleteById(cartId);
     }
 


### PR DESCRIPTION
- 장바구니 조회 시 마지막 수정일 기준 24시간 초과하면 해당 장바구니 삭제
- CartEmptyException, CartExpiredException 예외 처리 클래스 추가
- CartRepository에 최대 수정일 조회 쿼리 메서드 추가

Closes #49

## #️⃣연관된 이슈

Feat: 장바구니 만료 기능 추가 #49

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 장바구니 만료시 삭제하는 로직을 
장바구니 조회시 수정일 기준 24시간이 지났으면 장바구니를 삭제하는 방식으로 구현했습니다
`@Scheduled`로 관리하면 조회를 안 해도 자동 삭제되는데 일단은 로직상 문제가 없을것 같아서 
조회시 삭제하는 방식으로 구현했습니다 
의견있으시면 코멘트 부탁드려요!
